### PR TITLE
Remove regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ keywords = [
 ]
 license = "BSD-3-Clause"
 edition = "2021"
-
-[dependencies]
-regex = "1.10.0"


### PR DESCRIPTION
`regex` is quite a heavy dependency, and this crate is the only reason my project needs to pull it in.

This PR removes the dependency by using std Rust code instead. This also speeds up percent encoding quite a bit (when benchmarking an existing test):

- old: bench_literal_expansion:      10,046.55 ns/iter (+/- 477.77)
- new: bench_literal_expansion:            85.61 ns/iter (+/- 3.48)